### PR TITLE
Ship-gates: API.md usage stance + README unofficial & Gatekeeper notes

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,9 +24,11 @@ or changes an API call must update this file and keep the guardrails true.
    renderers never poll.
 5. **Explicit-only writes.** A write fires only on a deliberate user action (Save draft,
    Submit). Nothing in the sync tick or any background path ever writes.
-6. **On-device-only storage.** Tokens (Electron safeStorage), the JSON snapshot cache per feed
-   per account, and the seen-ledger live on the user's device. Nothing syncs to any server,
-   ours or otherwise; no telemetry.
+6. **On-device-only storage.** Local tokens (Electron safeStorage), the JSON snapshot cache
+   per feed per account, and the seen-ledger stay on-device. The only data that leaves the
+   device is what the API calls themselves carry — authenticated reads and the explicit
+   Task Answer writes above, sent to Cognisia's API. No third-party servers, no sync of app
+   data, no telemetry.
 7. **Distinctive User-Agent.** Every request carries
    `EdunexPlus/<version> (+https://github.com/pablonification/edunex-plus)`. Never spoof a
    browser User-Agent. The point is recognizability: Cognisia can identify — and optionally

--- a/API.md
+++ b/API.md
@@ -1,0 +1,107 @@
+# API.md — how Edunex Plus uses the EduNex API
+
+The EduNex API (`https://api-edunex.cognisia.id`) is **undocumented and vendor-hosted** by
+Cognisia. Edunex Plus is not an official client: it talks to the same API the EduNex web app
+uses, with the user's own session, under the guardrails below.
+
+This file is the project's API-usage stance. Every contributor inherits it; any PR that adds
+or changes an API call must update this file and keep the guardrails true.
+
+## The guardrails
+
+1. **Unofficial.** Edunex Plus is an independent, community-built client. It is not an ITB or
+   Cognisia product, and the lowercase-n "Edunex Plus" mark is deliberately distinct from
+   Cognisia's EduNex trademark.
+2. **Bring-your-own-session.** The app uses the logged-in user's own session. Login happens
+   through the real INA account SSO inside an embedded webview; the password only ever reaches
+   Microsoft's sign-in page and never touches Edunex Plus.
+3. **Read-mostly.** Reads dominate. The only writes anywhere in the client are the Task
+   Answer draft-save and submit (on explicit user action) — see [The only writes](#the-only-writes).
+4. **≥60s jittered polling, with backoff.** One unified main-process tick, cadence 90s ± 30s
+   jittered. The hard floor is 60 seconds between polls; never poll faster. Errors back off
+   exponentially. Presence detection is clock math on the explicit window fields in the
+   payload — it never becomes extra polling. All background work lives in the main process;
+   renderers never poll.
+5. **Explicit-only writes.** A write fires only on a deliberate user action (Save draft,
+   Submit). Nothing in the sync tick or any background path ever writes.
+6. **On-device-only storage.** Tokens (Electron safeStorage), the JSON snapshot cache per feed
+   per account, and the seen-ledger live on the user's device. Nothing syncs to any server,
+   ours or otherwise; no telemetry.
+7. **Distinctive User-Agent.** Every request carries
+   `EdunexPlus/<version> (+https://github.com/pablonification/edunex-plus)`. Never spoof a
+   browser User-Agent. The point is recognizability: Cognisia can identify — and optionally
+   allowlist or rate-limit — this client's traffic.
+8. **Courtesy notice, shipped regardless.** Shipping does not wait for permission or for a
+   reply: the owner sends a courtesy email to Cognisia/ITB describing the project and these
+   guardrails, and offering to coordinate.
+
+## Base URL and auth
+
+- Base URL: `https://api-edunex.cognisia.id` (vendor-hosted by Cognisia, not by ITB).
+- The login webview completes the real SSO flow (broker `sso-edunex.itb.ac.id` → Azure AD/Entra,
+  MFA included) with zero popups. After the redirect back, the app reads `localStorage.auth`
+  from the webview partition and extracts `accessToken`, `refreshToken`, `expirationDate`,
+  `verified`, and the `accounts` map.
+- Every API call sends `Authorization: Bearer <accessToken>`.
+- **No refresh logic.** The SPA never refreshes either (the refresh token is write-only; tokens
+  are minted server-side; observed JWTs live ~1 year while the SPA's `expirationDate` is a 2069
+  sentinel). On a 401 or a missing token, sync pauses and the app opens the interactive
+  "please sign in again" moment — recovery is never silent, because the Azure AD and SSO-broker
+  cookies do not survive app restarts.
+- Auth0 code in the SPA is dead code; the app ignores it.
+
+## Endpoints the app calls
+
+All facts below were verified against the live API with a real student session (prototype
+spikes, September 2026). Reads only — all of these are `GET`:
+
+| Endpoint | Purpose | Response shape |
+| --- | --- | --- |
+| `GET /todo` | Aggregated To Do feed for the account (pending Tasks, exams, questions, modules) | Plain JSON: `{tasks: [], exams: [], questions: [], modules: []}` |
+| `GET /course/courses` | Courses of the current Period | Plain JSON |
+| `GET /course/tasks` | Tasks for a course | JSON-API envelope: `{meta, data, links}`, items `type` / `id` / `attributes` / `links` — unlike `/todo`'s plain shape |
+| `GET /exam/exams` | Exams list (read-only in v1) | Plain JSON |
+| `GET /course/agenda` | Course agenda (meetings, with Vicon tags for online sessions) | Plain array: items carry `type`, `course_name`, `name`, `start_at`, `end_at` |
+| `GET /course/presences/list` | Presence records per course | Plain array: items carry `course_id`, `course_code`, `courses_name`, `class_id`, `class_name`, `semester`, `year`, `presences` |
+| `GET /notifications/{userId}` | Notification feed | `{data: …}`. Note the bare path **404s**: `GET /notifications` without the user id returns 404 |
+
+Two envelope regimes exist — `/todo` returns plain JSON while `/course/tasks` speaks JSON-API —
+so the API client normalizes at the boundary rather than letting callers care.
+
+Also verified but **not called**: `PATCH /notifications` (notification read-state) exists;
+v1 has no flow that uses it. It is recorded here so nobody rediscovers it — and if it is ever
+adopted, it is a write and falls under the explicit-only rule.
+
+## The only writes
+
+Task Answers (the "saved ≠ submitted" surface) and nothing else:
+
+- `POST /course/task/answers` — create a draft Answer, `task_id` in the body → `201`.
+- `PATCH /course/task/answers/{answerId}` — update a draft Answer.
+- Final submit: the exact wire contract is a **bounded known-unknown** — expected
+  `is_sent: 1` plus a sender field, captured on the user's next real submission (tracked in
+  issue #12). Until then the app never guesses it, and there is **no resubmit affordance**.
+- Status derivation uses **`is_sent` only** (`0` = draft): `sent_at` is stamped on drafts too,
+  so the app never displays it.
+- Both draft calls fire only on an explicit click. There are no other `POST`/`PATCH`/`PUT`/
+  `DELETE` calls in the client.
+
+## What the app deliberately does not do
+
+- **No writes beyond the list above.** No profile changes, no discussion/CRS posts, no
+  notification mutations in v1.
+- **No past-period browsing.** The server refuses it; v1 shows current/available Periods only.
+- **No socket usage.** The vendor's sockets carry only CRS and messaging; the app uses HTTP
+  polling exclusively.
+- **No SPA-internal endpoints.** The web app calls many more paths (`/public/*`, `/login/me`,
+  `/message/unread`, announcements, …); the app calls only the subset listed above.
+- **No scraping or replay** of endpoints not listed here, and no polling under the 60s floor.
+
+## Verification status
+
+- Endpoint existence, response shapes, and the auth capture were verified live via the
+  prototype spikes (`prototype/auth-spike`, `prototype/sync-spike`, September 2026).
+- The final-submit contract and the file-attachment upload endpoint behind
+  `answers[].files[]` are pending capture (issue #12); the submission slice's final wiring
+  waits on it.
+- Any new endpoint must land here first, verified, before the client calls it.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ is unaffected.
   shortcut — installed builds are fine, bare-exe runs may not toast.
 - **Linux:** notifications go through libnotify; action-button support varies by desktop.
 
+Per-platform notification notes and verification records live in
+[docs/platform-notifications.md](docs/platform-notifications.md).
+
 ## Development
 
 Electron + TypeScript, performance-disciplined: all background work (polling, diffing,

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Edunex Plus answers with a calm, minimal desktop client that wraps the EduNex AP
 
 - **To Do first** — the aggregated list of pending Tasks and exams for your account, on one screen.
 - **OS notifications** — a polite background poll (never faster than once a minute, jittered,
-  with backoff) raises a notification the moment a new Task appears or a Presence window opens.
+  with backoff) notices a new Task or an opened Presence window and raises the OS notification
+  on its next poll — within a couple of minutes at worst, longer while errors back off.
 - **Status-first submissions** — draft, submitted, and overdue are unmistakable at a glance;
-  Save-draft is visually quiet, Submit is a deliberate act with a green receipt.
+  Save-draft is visually quiet. Submit — a deliberate act with a green receipt — lands only
+  once the final-submit wire contract is verified (issue #12).
 - **Calm shell** — a floating sidebar and content panel; hide the features you never use.
 - **Offline reading** — the last-synced feeds stay readable without a connection.
 - **Lives in the tray** — closing the window keeps notifications flowing.
@@ -33,9 +35,11 @@ v1 targets the **Student** experience only.
 
 You sign in with your real **INA account** through the genuine ITB SSO inside an embedded
 webview. Your password only ever reaches Microsoft's sign-in page — it never touches
-Edunex Plus. The app captures the resulting session and talks to the API directly; tokens are
-stored encrypted (Electron safeStorage) and **everything stays on your device** — nothing
-syncs to any server, and there is no telemetry.
+Edunex Plus. The app captures the resulting session and talks to the API directly. Local
+tokens (Electron safeStorage), the per-feed snapshot cache, and the seen-ledger stay
+on-device — the only data that leaves your device is what the API calls themselves carry:
+authenticated reads and the explicit Task Answer writes, sent to Cognisia's API. No
+third-party servers, no sync of app data, no telemetry.
 
 ## Vendor respect
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Edunex Plus
+
+**Unofficial, community-built desktop client for ITB's EduNex LMS** — for macOS, Windows, and
+Linux.
+
+> ⚠️ **Unofficial — not an ITB or Cognisia product.**
+> Edunex Plus is an independent open-source project built by students. It is not affiliated
+> with, endorsed by, or connected to Institut Teknologi Bandung (ITB) or to Cognisia, the
+> vendor that builds and operates EduNex. "EduNex" is Cognisia's product; the lowercase-n
+> "Edunex Plus" mark is deliberately distinct from it. Use at your own risk: the app drives
+> your personal EduNex session, and your account remains your responsibility.
+
+## What it is
+
+EduNex is where ITB students live — and daily it fails them in quiet ways: new Tasks appear
+without a notification, Presence windows open and close unnoticed, a saved draft looks
+exactly like a real submission, and the UI shouts from every direction.
+
+Edunex Plus answers with a calm, minimal desktop client that wraps the EduNex API:
+
+- **To Do first** — the aggregated list of pending Tasks and exams for your account, on one screen.
+- **OS notifications** — a polite background poll (never faster than once a minute, jittered,
+  with backoff) raises a notification the moment a new Task appears or a Presence window opens.
+- **Status-first submissions** — draft, submitted, and overdue are unmistakable at a glance;
+  Save-draft is visually quiet, Submit is a deliberate act with a green receipt.
+- **Calm shell** — a floating sidebar and content panel; hide the features you never use.
+- **Offline reading** — the last-synced feeds stay readable without a connection.
+- **Lives in the tray** — closing the window keeps notifications flowing.
+
+v1 targets the **Student** experience only.
+
+## How login works
+
+You sign in with your real **INA account** through the genuine ITB SSO inside an embedded
+webview. Your password only ever reaches Microsoft's sign-in page — it never touches
+Edunex Plus. The app captures the resulting session and talks to the API directly; tokens are
+stored encrypted (Electron safeStorage) and **everything stays on your device** — nothing
+syncs to any server, and there is no telemetry.
+
+## Vendor respect
+
+The EduNex API is undocumented and vendor-hosted by Cognisia. This project treats that as a
+privilege, not a right. The full stance — unofficial, bring-your-own-session, read-mostly,
+≥60s jittered polling, explicit-only writes, on-device-only storage, distinctive User-Agent —
+is spelled out in [API.md](API.md), which also lists every endpoint the app calls. It binds
+all contributors.
+
+## Platform notes
+
+### macOS: ad-hoc signing & Gatekeeper (known limitation)
+
+macOS builds are **ad-hoc signed**, not Developer ID signed and not notarized. This is a
+deliberate trade-off: Electron 42+ delivers OS notifications only to validly signed bundles,
+and ad-hoc signing satisfies that without requiring an Apple Developer account.
+
+The consequence: **a downloaded (not locally built) app is blocked by Gatekeeper on first
+launch**, because macOS cannot verify its signature against Apple. To open it, right-click the
+app and choose **Open**, or approve it under System Settings → Privacy & Security ("Open
+Anyway"). This friction is accepted and documented rather than solved — building from source
+is unaffected.
+
+### Windows & Linux
+
+- **Windows:** notifications need the app's AppUserModelID registered via a Start-Menu
+  shortcut — installed builds are fine, bare-exe runs may not toast.
+- **Linux:** notifications go through libnotify; action-button support varies by desktop.
+
+## Development
+
+Electron + TypeScript, performance-disciplined: all background work (polling, diffing,
+caching, notifications) lives in the main process. The renderer is React with Tailwind v4.
+
+```sh
+npm install
+npm run dev     # vite + electron
+npm test        # vitest
+```
+
+Tests assert external behavior at seams (a fake EduNex API client; the preload-exposed API
+mock) rather than implementation details. Domain language — Period, Task, Presence, Vicon,
+To Do, INA account — is defined in [CONTEXT.md](CONTEXT.md).
+
+## License
+
+MIT.


### PR DESCRIPTION
Implements the docs half of #31 (ship-gates from the API-usage stance decided in #17). Refs #31 — the issue stays open for the owner-action item (courtesy email, draft below).

## What's here

- **`API.md`** — the project's API-usage stance for the undocumented, vendor-hosted `api-edunex.cognisia.id`: the eight guardrails (unofficial, bring-your-own-session, read-mostly, ≥60s jittered polling with backoff, explicit-only writes, on-device-only storage, distinctive User-Agent `EdunexPlus/<version>`, courtesy notice shipped regardless), the verified endpoint table with response shapes, the only writes (Task Answer draft-save/submit; final-submit contract pending #12), and what the app deliberately never does. Every fact was verified against the live API via the prototype spikes (`prototype/auth-spike`, `prototype/sync-spike`, September 2026).
- **`README.md`** — prominent unofficial disclaimer (not an ITB or Cognisia product; lowercase-n mark deliberate), how login works (password never touches the app), vendor-respect summary linking API.md, the **macOS ad-hoc-signing / Gatekeeper limitation** (downloaded builds are blocked on first launch; right-click → Open; Electron 42+ notification requirement), Windows/Linux notification notes with a link to `docs/platform-notifications.md`, and a short development section.

## Acceptance criteria status

| AC | Status |
| --- | --- |
| API.md lists endpoints + guardrails | ✅ this PR |
| README unofficial disclaimer + Gatekeeper/ad-hoc note | ✅ this PR |
| App metadata/About unofficial qualifier | ✅ on `main` since #34 (app shell): `package.json` description + `app.setAboutPanelOptions` credits (`src/main/main.ts:193`) |
| Courtesy email sent | ⏳ owner action — draft below |

## Branch note

Cut from `main` before the app shell landed; now **rebased onto post-#34 `main`**, so the PR contains only the two docs files on top of the current app code. The README's Development section matches the merged `package.json` scripts.

## Courtesy email draft (owner action — copy, sign, send)

> **To:** Cognisia (EduNex team) — cc ITB IT services
> **Subject:** Courtesy notice — unofficial open-source desktop client for EduNex ("Edunex Plus")
>
> Dear Cognisia team,
>
> I'm the maintainer of **Edunex Plus**, a free, open-source desktop client for EduNex built for ITB students (github.com/pablonification/edunex-plus). It is an unofficial community project — not an ITB or Cognisia product — and the lowercase-n name is deliberately distinct from your EduNex mark.
>
> I'm writing as a courtesy before release, since the project talks to the same API as the EduNex web app. I want you to know exactly how it behaves:
>
> - Users sign in through the real INA-account SSO inside an embedded webview; the app uses **each user's own session**. Passwords never touch the app.
> - Use is **read-mostly**: the only writes are a task answer's draft-save and submit, on explicit user action.
> - Polling is **never faster than once per 60 seconds** (90s ± 30s jittered, with backoff), from a single background process.
> - All data (tokens, caches) is stored **on-device only** — nothing syncs anywhere, and there is no telemetry.
> - Every request carries a **distinctive User-Agent** (`EdunexPlus/<version> …`), so your team can recognize and, if you wish, allowlist or rate-limit this traffic.
> - The full stance and the endpoint list are published in the repository's `API.md`.
>
> No response is needed — we ship without prior permission and accept that the API is yours to govern. But if you'd like to discuss, request changes, or coordinate (e.g. an allowlist), I'd be glad to: [your email].
>
> Best regards,
> [Your name]

## Review notes

Two-axis review (standards + spec) ran on the diff; applied fixes: restored the "ship without prior permission" half of the stance, moved unused `PATCH /notifications` out of the called-endpoints table, restored the "Electron 42+" notification floor, and aligned prose with the CONTEXT.md glossary (Presence, submission). CodeRabbit's three findings addressed in ce3af46: narrowed the on-device-only guarantee (API reads and explicit writes do go to Cognisia; only local storage stays on-device), aligned the notification promise with the polling cadence (next poll, not "the moment"), and marked Submit as pending contract verification (#12) in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a project overview for Edunex Plus, an unofficial desktop client for ITB’s EduNex LMS.
  - Documented task aggregation, notifications, offline reading, tray behavior, supported platforms, and development setup.
  - Added guidance for INA-account sign-in through embedded ITB SSO, including encrypted on-device token and cache storage.
  - Documented authenticated API reads and explicit Task Answer writes sent to Cognisia.
  - Clarified polling-related notification delays, excluded behaviors, response handling, and pending final-submit/upload contract verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->