### PR TITLE
Auth: webview login → token capture → restart-restore (#18)

### DIFF
--- a/src/main/api/client.test.ts
+++ b/src/main/api/client.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEdunexApi } from "./client";
+
+function okResponse(body: unknown = {}) {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+function fetchOk() {
+  return vi.fn(async () => okResponse({ id: 190136 }));
+}
+
+describe("edunex api client", () => {
+  it("calls the endpoint with the captured bearer token and the app's User-Agent", async () => {
+    const fetchImpl = fetchOk();
+    const api = createEdunexApi({
+      baseUrl: "https://api-edunex.cognisia.id",
+      getToken: () => "tok-123",
+      userAgent: "EdunexPlus/0.0.1",
+      fetchImpl,
+    });
+
+    const result = await api.get("/login/me");
+
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("https://api-edunex.cognisia.id/login/me");
+    expect(init.headers.get("Authorization")).toBe("Bearer tok-123");
+    expect(init.headers.get("User-Agent")).toBe("EdunexPlus/0.0.1");
+  });
+
+  it("reports 401s and signals the session is gone", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 401 }));
+    const onUnauthorized = vi.fn();
+    const api = createEdunexApi({
+      baseUrl: "https://api-edunex.cognisia.id",
+      getToken: () => "stale",
+      onUnauthorized,
+      fetchImpl,
+    });
+
+    const result = await api.get("/login/me");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a missing token as unauthorized without hitting the network", async () => {
+    const fetchImpl = fetchOk();
+    const onUnauthorized = vi.fn();
+    const api = createEdunexApi({
+      baseUrl: "https://api-edunex.cognisia.id",
+      getToken: () => null,
+      onUnauthorized,
+      fetchImpl,
+    });
+
+    const result = await api.get("/login/me");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives network failures as a non-auth error (offline ≠ signed out)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+    const onUnauthorized = vi.fn();
+    const api = createEdunexApi({
+      baseUrl: "https://api-edunex.cognisia.id",
+      getToken: () => "tok",
+      onUnauthorized,
+      fetchImpl,
+    });
+
+    const result = await api.get("/todo");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(0);
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onUnauthorized for other 4xx/5xx responses", async () => {
+    const fetchImpl = vi.fn(async () => new Response("", { status: 500 }));
+    const onUnauthorized = vi.fn();
+    const api = createEdunexApi({
+      baseUrl: "https://api-edunex.cognisia.id",
+      getToken: () => "tok",
+      onUnauthorized,
+      fetchImpl,
+    });
+
+    const result = await api.get("/todo");
+
+    expect(result.status).toBe(500);
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/api/client.ts
+++ b/src/main/api/client.ts
@@ -1,0 +1,71 @@
+/**
+ * Direct API client for the vendor API (api-edunex.cognisia.id) — the app
+ * talks to it with the bearer token captured from the webview, never with a
+ * password (spec: auth & session, API stance). Read-mostly; v1 auth slice
+ * only needs GETs to verify a session.
+ */
+
+export interface ApiResult {
+  /** HTTP status; 0 means the request never completed (offline, DNS, …).
+   * A network failure is not an auth failure — only 401 is. */
+  status: number;
+  ok: boolean;
+  body: unknown;
+}
+
+export interface EdunexApi {
+  get(path: string): Promise<ApiResult>;
+}
+
+export interface EdunexApiOptions {
+  baseUrl: string;
+  /** Current access token, or null when signed out. */
+  getToken: () => string | null;
+  /** Distinctive User-Agent so Cognisia can recognize (spec: API stance). */
+  userAgent: string;
+  /** Fired on 401 or missing token: the session is gone and the app must
+   * pause into the re-login moment. Never fired for network errors. */
+  onUnauthorized?: () => void;
+  fetchImpl?: typeof fetch;
+}
+
+export function createEdunexApi(options: EdunexApiOptions): EdunexApi {
+  const {
+    baseUrl,
+    getToken,
+    userAgent,
+    onUnauthorized,
+    fetchImpl = fetch,
+  } = options;
+
+  async function get(path: string): Promise<ApiResult> {
+    const token = getToken();
+    if (!token) {
+      onUnauthorized?.();
+      return { status: 401, ok: false, body: null };
+    }
+
+    let response: Response;
+    try {
+      response = await fetchImpl(`${baseUrl}${path}`, {
+        headers: new Headers({
+          Authorization: `Bearer ${token}`,
+          "User-Agent": userAgent,
+        }),
+      });
+    } catch {
+      return { status: 0, ok: false, body: null };
+    }
+
+    if (response.status === 401) onUnauthorized?.();
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch {
+      // Empty or non-JSON body — fine for a status-only check.
+    }
+    return { status: response.status, ok: response.ok, body };
+  }
+
+  return { get };
+}

--- a/src/main/app-menu.test.ts
+++ b/src/main/app-menu.test.ts
@@ -39,4 +39,24 @@ describe("buildAppMenuTemplate", () => {
     expect(roles).toContain("editMenu");
     expect(roles).toContain("windowMenu");
   });
+
+  it("includes the dev-only Simulate 401 item only when a handler is supplied", () => {
+    const findDevItem = (t: ReturnType<typeof buildAppMenuTemplate>) => {
+      const viewMenu = t.find((item) => "label" in item && item.label === "View");
+      return (viewMenu!.submenu as { label?: string }[]).find(
+        (item) => item.label === "Simulate 401 (dev)",
+      );
+    };
+
+    const without = buildAppMenuTemplate("Edunex Plus", NAV_VIEWS, { gotoView: vi.fn() });
+    expect(findDevItem(without)).toBeUndefined();
+
+    const simulate = vi.fn();
+    const withDev = buildAppMenuTemplate("Edunex Plus", NAV_VIEWS, {
+      gotoView: vi.fn(),
+      simulateUnauthorized: simulate,
+    });
+    findDevItem(withDev)!.click!();
+    expect(simulate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/main/app-menu.ts
+++ b/src/main/app-menu.ts
@@ -11,6 +11,8 @@ import type { MenuItemConstructorOptions } from "electron";
  */
 export interface AppMenuHandlers {
   gotoView(view: string): void;
+  /** Dev builds only: fake a 401 to demo the re-login moment end-to-end. */
+  simulateUnauthorized?(): void;
 }
 
 export function buildAppMenuTemplate(
@@ -25,6 +27,13 @@ export function buildAppMenuTemplate(
     accelerator: `CmdOrCtrl+${index + 1}`,
     click: () => handlers.gotoView(view.key),
   }));
+
+  const devAuthItem: MenuItemConstructorOptions | null = handlers.simulateUnauthorized
+    ? {
+        label: "Simulate 401 (dev)",
+        click: () => handlers.simulateUnauthorized!(),
+      }
+    : null;
 
   const macAppMenu: MenuItemConstructorOptions = {
     label: appName,
@@ -53,6 +62,7 @@ export function buildAppMenuTemplate(
         { type: "separator" },
         { role: "reload" },
         { role: "toggleDevTools" },
+        ...(devAuthItem ? [{ type: "separator" } as const, devAuthItem] : []),
         { type: "separator" },
         { role: "resetZoom" },
         { role: "zoomIn" },

--- a/src/main/auth/auth-controller.ts
+++ b/src/main/auth/auth-controller.ts
@@ -94,7 +94,9 @@ export function createAuthController(opts: {
       const maybeStart = (url: string) => {
         if (isEdunexOrigin(url)) {
           if (capture.start(onCaptured)) {
-            console.log("[auth] polling for localStorage.auth on", url);
+            // Path only: edunex URLs can carry the bearer token as a query
+            // param (webhook/sso) — never log those.
+            console.log("[auth] polling for localStorage.auth on", new URL(url).pathname);
           }
         } else {
           capture.stop();

--- a/src/main/auth/auth-controller.ts
+++ b/src/main/auth/auth-controller.ts
@@ -1,0 +1,110 @@
+import { safeStorage } from "electron";
+import type { AuthStatus, CapturedAuth } from "../../shared/auth";
+import { AUTH_PARTITION } from "../../shared/auth";
+import { createSessionStore, type SessionCodec } from "./session-store";
+import { createSessionManager, type SessionManager } from "./session-manager";
+import { createAuthCapture } from "./capture";
+import { createEdunexApi } from "../api/client";
+
+/** The vendor API the captured bearer token talks to (spec: API stance). */
+export const EDUNEX_API_BASE_URL = "https://api-edunex.cognisia.id";
+export { AUTH_PARTITION };
+
+/**
+ * Glue for the auth slice (#18): the testable pieces are session-store,
+ * capture and session-manager; this module owns the Electron-side wiring —
+ * safeStorage as the codec, the real API client, the capture loop attached
+ * to the login webview's webContents, and popup-free in-window navigation.
+ */
+export interface AuthController {
+  /** null until the startup restore finished — the renderer holds the shell
+   * back so a restored session never flashes the login view. */
+  status(): AuthStatus | null;
+  restore(): Promise<void>;
+  startLogin(): void;
+  dismissLogin(): void;
+  attachWebview(contents: Electron.WebContents): void;
+  detachWebview(contents: Electron.WebContents): void;
+}
+
+export function createAuthController(opts: {
+  sessionStorePath: string;
+  appVersion: string;
+  /** Push a status change to the renderer. */
+  broadcast(status: AuthStatus): void;
+}): AuthController {
+  const codec: SessionCodec = {
+    encrypt(plaintext) {
+      if (!safeStorage.isEncryptionAvailable()) {
+        throw new Error("safeStorage is unavailable; refusing to store tokens");
+      }
+      return safeStorage.encryptString(plaintext);
+    },
+    decrypt(blob) {
+      return safeStorage.decryptString(blob);
+    },
+  };
+
+  const store = createSessionStore(opts.sessionStorePath, codec);
+
+  // api ↔ manager are mutually referential; the token getter is bound after
+  // the manager exists, before either is ever used.
+  let getToken: () => string | null = () => null;
+  const api = createEdunexApi({
+    baseUrl: EDUNEX_API_BASE_URL,
+    getToken: () => getToken(),
+    userAgent: `EdunexPlus/${opts.appVersion} (desktop client; +https://github.com/pablonification/edunex-plus)`,
+    onUnauthorized: () => manager.handleUnauthorized(),
+  });
+  const manager: SessionManager = createSessionManager({
+    store,
+    api,
+    onChange: opts.broadcast,
+  });
+  getToken = () => manager.accessToken();
+
+  let restored = false;
+  const captures = new Map<number, ReturnType<typeof createAuthCapture>>();
+
+  return {
+    status: () => (restored ? manager.status() : null),
+    restore: async () => {
+      await manager.restore();
+      restored = true;
+    },
+    startLogin: () => manager.startLogin(),
+    dismissLogin: () => manager.dismissLogin(),
+
+    attachWebview(contents) {
+      // Zero popups (acceptance criteria): Azure AD / the SSO broker must
+      // finish in-window. Anything asking for a new window is folded back
+      // into the same webview.
+      contents.setWindowOpenHandler(({ url }) => {
+        if (/^https?:/i.test(url)) void contents.loadURL(url).catch(() => {});
+        return { action: "deny" };
+      });
+
+      // The SPA writes localStorage.auth ~2s after the redirect-back lands
+      // (auth-spike). Poll until it shows up — MFA may take as long as the
+      // human needs, so there is no timeout.
+      const capture = createAuthCapture(
+        () => contents.executeJavaScript("localStorage.getItem('auth')", true),
+        { intervalMs: 1000 },
+      );
+      capture.start((auth: CapturedAuth) => void manager.capture(auth));
+      captures.set(contents.id, capture);
+
+      // When the renderer unmounts the webview (login done or dismissed) its
+      // webContents is destroyed — end the poll with it.
+      contents.once("destroyed", () => {
+        capture.stop();
+        captures.delete(contents.id);
+      });
+    },
+
+    detachWebview(contents) {
+      captures.get(contents.id)?.stop();
+      captures.delete(contents.id);
+    },
+  };
+}

--- a/src/main/auth/auth-controller.ts
+++ b/src/main/auth/auth-controller.ts
@@ -93,8 +93,9 @@ export function createAuthController(opts: {
       const capture = createAuthCapture(readWithTimeout(contents), { intervalMs: 1000 });
       const maybeStart = (url: string) => {
         if (isEdunexOrigin(url)) {
-          console.log("[auth] edunex origin — polling for localStorage.auth");
-          capture.start(onCaptured);
+          if (capture.start(onCaptured)) {
+            console.log("[auth] polling for localStorage.auth on", url);
+          }
         } else {
           capture.stop();
         }

--- a/src/main/auth/auth-controller.ts
+++ b/src/main/auth/auth-controller.ts
@@ -1,6 +1,5 @@
 import { safeStorage } from "electron";
 import type { AuthStatus, CapturedAuth } from "../../shared/auth";
-import { AUTH_PARTITION } from "../../shared/auth";
 import { createSessionStore, type SessionCodec } from "./session-store";
 import { createSessionManager, type SessionManager } from "./session-manager";
 import { createAuthCapture } from "./capture";
@@ -8,7 +7,6 @@ import { createEdunexApi } from "../api/client";
 
 /** The vendor API the captured bearer token talks to (spec: API stance). */
 export const EDUNEX_API_BASE_URL = "https://api-edunex.cognisia.id";
-export { AUTH_PARTITION };
 
 /**
  * Glue for the auth slice (#18): the testable pieces are session-store,
@@ -22,9 +20,7 @@ export interface AuthController {
   status(): AuthStatus | null;
   restore(): Promise<void>;
   startLogin(): void;
-  dismissLogin(): void;
   attachWebview(contents: Electron.WebContents): void;
-  detachWebview(contents: Electron.WebContents): void;
 }
 
 export function createAuthController(opts: {
@@ -73,14 +69,16 @@ export function createAuthController(opts: {
       restored = true;
     },
     startLogin: () => manager.startLogin(),
-    dismissLogin: () => manager.dismissLogin(),
 
     attachWebview(contents) {
       // Zero popups (acceptance criteria): Azure AD / the SSO broker must
       // finish in-window. Anything asking for a new window is folded back
-      // into the same webview.
+      // into the same webview — deferred off the handler per Electron's
+      // guidance against navigating synchronously from it.
       contents.setWindowOpenHandler(({ url }) => {
-        if (/^https?:/i.test(url)) void contents.loadURL(url).catch(() => {});
+        if (/^https?:/i.test(url)) {
+          setTimeout(() => void contents.loadURL(url).catch(() => {}), 0);
+        }
         return { action: "deny" };
       });
 
@@ -100,11 +98,6 @@ export function createAuthController(opts: {
         capture.stop();
         captures.delete(contents.id);
       });
-    },
-
-    detachWebview(contents) {
-      captures.get(contents.id)?.stop();
-      captures.delete(contents.id);
     },
   };
 }

--- a/src/main/auth/auth-controller.ts
+++ b/src/main/auth/auth-controller.ts
@@ -67,10 +67,13 @@ export function createAuthController(opts: {
     restore: async () => {
       await manager.restore();
       restored = true;
+      console.log("[auth] startup restore complete:", manager.status());
     },
     startLogin: () => manager.startLogin(),
 
     attachWebview(contents) {
+      console.log("[auth] login webview attached");
+
       // Zero popups (acceptance criteria): Azure AD / the SSO broker must
       // finish in-window. Anything asking for a new window is folded back
       // into the same webview — deferred off the handler per Electron's
@@ -84,12 +87,20 @@ export function createAuthController(opts: {
 
       // The SPA writes localStorage.auth ~2s after the redirect-back lands
       // (auth-spike). Poll until it shows up — MFA may take as long as the
-      // human needs, so there is no timeout.
-      const capture = createAuthCapture(
-        () => contents.executeJavaScript("localStorage.getItem('auth')", true),
-        { intervalMs: 1000 },
-      );
-      capture.start((auth: CapturedAuth) => void manager.capture(auth));
+      // human needs, so there is no timeout. The loop only runs while the
+      // webview sits on the EduNex origin: localStorage.auth only exists
+      // there, and a reader against a not-yet-committed frame can hang.
+      const capture = createAuthCapture(readWithTimeout(contents), { intervalMs: 1000 });
+      const maybeStart = (url: string) => {
+        if (isEdunexOrigin(url)) {
+          console.log("[auth] edunex origin — polling for localStorage.auth");
+          capture.start(onCaptured);
+        } else {
+          capture.stop();
+        }
+      };
+      contents.on("did-navigate", (_event, url) => maybeStart(url));
+      contents.on("did-navigate-in-page", (_event, url) => maybeStart(url));
       captures.set(contents.id, capture);
 
       // When the renderer unmounts the webview (login done or dismissed) its
@@ -100,4 +111,38 @@ export function createAuthController(opts: {
       });
     },
   };
+
+  function onCaptured(auth: CapturedAuth) {
+    console.log("[auth] session captured from webview, verifying");
+    void manager.capture(auth);
+  }
+}
+
+function isEdunexOrigin(url: string): boolean {
+  try {
+    return new URL(url).host === "edunex.itb.ac.id";
+  } catch {
+    return false;
+  }
+}
+
+/** Every read must settle (a reader against a wedged frame would otherwise
+ * block the poll loop's in-flight guard forever). */
+function readWithTimeout(contents: Electron.WebContents) {
+  return () =>
+    new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("auth read timed out")), 5000);
+      contents
+        .executeJavaScript("localStorage.getItem('auth')", true)
+        .then(
+          (value) => {
+            clearTimeout(timer);
+            resolve(value);
+          },
+          (err: unknown) => {
+            clearTimeout(timer);
+            reject(err);
+          },
+        );
+    });
 }

--- a/src/main/auth/auth-controller.ts
+++ b/src/main/auth/auth-controller.ts
@@ -20,6 +20,8 @@ export interface AuthController {
   status(): AuthStatus | null;
   restore(): Promise<void>;
   startLogin(): void;
+  /** Dev-only: fake a 401 to demo the re-login moment without the vendor API. */
+  simulateUnauthorized(): void;
   attachWebview(contents: Electron.WebContents): void;
 }
 
@@ -70,6 +72,10 @@ export function createAuthController(opts: {
       console.log("[auth] startup restore complete:", manager.status());
     },
     startLogin: () => manager.startLogin(),
+    simulateUnauthorized: () => {
+      console.log("[auth] dev: simulating a 401 — session should pause into re-login");
+      manager.handleUnauthorized();
+    },
 
     attachWebview(contents) {
       console.log("[auth] login webview attached");

--- a/src/main/auth/capture.test.ts
+++ b/src/main/auth/capture.test.ts
@@ -14,11 +14,19 @@ describe("parseCapturedAuth", () => {
     expect(parseCapturedAuth(validRaw)).toEqual(validRaw);
   });
 
+  it("accepts accounts as the SSO webhook's array of identities", () => {
+    const withArray = {
+      ...validRaw,
+      accounts: [{ id: 190136, level: "STUDENT" }, { id: 187138, level: "LECTURER" }],
+    };
+    expect(parseCapturedAuth(withArray)).toEqual(withArray);
+  });
+
   it("rejects null, partial and wrong-typed payloads", () => {
     expect(parseCapturedAuth(null)).toBeNull();
     expect(parseCapturedAuth({})).toBeNull();
     expect(parseCapturedAuth({ ...validRaw, accessToken: 42 })).toBeNull();
-    expect(parseCapturedAuth({ ...validRaw, accounts: [] })).toBeNull();
+    expect(parseCapturedAuth({ ...validRaw, accounts: "nope" })).toBeNull();
   });
 });
 

--- a/src/main/auth/capture.test.ts
+++ b/src/main/auth/capture.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { parseCapturedAuth, createAuthCapture } from "./capture";
+
+const validRaw = {
+  accessToken: "eyJ0eXAiOiJK.abc.def",
+  refreshToken: "def50200b172",
+  expirationDate: "2069-12-07T00:00:00.000Z",
+  verified: true,
+  accounts: { "0": { id: 190136 }, "1": { id: 2 } },
+};
+
+describe("parseCapturedAuth", () => {
+  it("accepts the auth JSON exactly as the SPA writes it", () => {
+    expect(parseCapturedAuth(validRaw)).toEqual(validRaw);
+  });
+
+  it("rejects null, partial and wrong-typed payloads", () => {
+    expect(parseCapturedAuth(null)).toBeNull();
+    expect(parseCapturedAuth({})).toBeNull();
+    expect(parseCapturedAuth({ ...validRaw, accessToken: 42 })).toBeNull();
+    expect(parseCapturedAuth({ ...validRaw, accounts: [] })).toBeNull();
+  });
+});
+
+describe("auth capture loop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function harness(initialStorage: unknown) {
+    let storage = initialStorage;
+    const executeJs = vi.fn(async () => storage);
+    return {
+      executeJs,
+      setStorage(next: unknown) {
+        storage = next;
+      },
+    };
+  }
+
+  it("polls localStorage.auth until it appears, then fires once and stops", async () => {
+    const h = harness(null);
+    const onCaptured = vi.fn();
+    const capture = createAuthCapture(h.executeJs, { intervalMs: 1000 });
+    capture.start(onCaptured);
+
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onCaptured).not.toHaveBeenCalled();
+    expect(h.executeJs).toHaveBeenCalledTimes(2);
+
+    // The SPA writes `auth` ~2s after the redirect-back (auth-spike).
+    h.setStorage(JSON.stringify(validRaw));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onCaptured).toHaveBeenCalledWith(validRaw);
+
+    expect(h.executeJs).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(h.executeJs).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores unparsable storage values and keeps polling", async () => {
+    const h = harness("not-json");
+    const onCaptured = vi.fn();
+    const capture = createAuthCapture(h.executeJs, { intervalMs: 1000 });
+    capture.start(onCaptured);
+
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(onCaptured).not.toHaveBeenCalled();
+    expect(h.executeJs).toHaveBeenCalledTimes(3);
+  });
+
+  it("stop ends polling without firing", async () => {
+    const h = harness(null);
+    const onCaptured = vi.fn();
+    const capture = createAuthCapture(h.executeJs, { intervalMs: 1000 });
+    capture.start(onCaptured);
+    capture.stop();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onCaptured).not.toHaveBeenCalled();
+  });
+
+  it("survives a rejected executeJavaScript (webview navigating)", async () => {
+    const executeJs = vi.fn(async () => {
+      throw new Error("frame detached");
+    });
+    const onCaptured = vi.fn();
+    const capture = createAuthCapture(executeJs, { intervalMs: 1000 });
+    capture.start(onCaptured);
+
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(executeJs).toHaveBeenCalledTimes(3);
+    expect(onCaptured).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/auth/capture.test.ts
+++ b/src/main/auth/capture.test.ts
@@ -83,6 +83,33 @@ describe("auth capture loop", () => {
     expect(onCaptured).not.toHaveBeenCalled();
   });
 
+  it("start while already running does not double-poll", async () => {
+    const h = harness(null);
+    const onCaptured = vi.fn();
+    const capture = createAuthCapture(h.executeJs, { intervalMs: 1000 });
+    capture.start(onCaptured);
+    capture.start(onCaptured);
+
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(h.executeJs).toHaveBeenCalledTimes(3);
+  });
+
+  it("restarts after stop for the next navigation onto the origin", async () => {
+    const h = harness(null);
+    const onCaptured = vi.fn();
+    const capture = createAuthCapture(h.executeJs, { intervalMs: 1000 });
+    capture.start(onCaptured);
+    capture.stop();
+    capture.start(onCaptured);
+
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(h.executeJs).toHaveBeenCalledTimes(3);
+
+    h.setStorage(JSON.stringify(validRaw));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onCaptured).toHaveBeenCalledWith(validRaw);
+  });
+
   it("survives a rejected executeJavaScript (webview navigating)", async () => {
     const executeJs = vi.fn(async () => {
       throw new Error("frame detached");

--- a/src/main/auth/capture.ts
+++ b/src/main/auth/capture.ts
@@ -44,10 +44,8 @@ export interface AuthCapture {
  */
 export function createAuthCapture(
   executeJs: AuthReader,
-  opts: { intervalMs: number; setTimeout?: typeof setTimeout; clearTimeout?: typeof clearTimeout },
+  opts: { intervalMs: number },
 ): AuthCapture {
-  const setTimeout_ = opts.setTimeout ?? setTimeout;
-  const clearTimeout_ = opts.clearTimeout ?? clearTimeout;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let inFlight = false;
   let done = false;
@@ -68,7 +66,7 @@ export function createAuthCapture(
     } finally {
       inFlight = false;
     }
-    if (!done) timer = setTimeout_(() => void poll(onCaptured), opts.intervalMs);
+    if (!done) timer = setTimeout(() => void poll(onCaptured), opts.intervalMs);
   }
 
   return {
@@ -79,7 +77,7 @@ export function createAuthCapture(
     stop() {
       done = true;
       if (timer) {
-        clearTimeout_(timer);
+        clearTimeout(timer);
         timer = null;
       }
     },

--- a/src/main/auth/capture.ts
+++ b/src/main/auth/capture.ts
@@ -1,0 +1,87 @@
+import type { CapturedAuth } from "../../shared/auth";
+
+/**
+ * Reading `localStorage.auth` out of the login webview — the capture step the
+ * auth-spike prototype proved (~2s after the SSO redirect-back lands on
+ * edunex.itb.ac.id).
+ */
+
+/** Accepts only the exact auth shape; anything else (login page leftovers,
+ * garbage, half-writes) is not a session. */
+export function parseCapturedAuth(raw: unknown): CapturedAuth | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const it = raw as Record<string, unknown>;
+  if (typeof it.accessToken !== "string" || it.accessToken.length === 0) return null;
+  if (typeof it.refreshToken !== "string" || it.refreshToken.length === 0) return null;
+  if (typeof it.expirationDate !== "string") return null;
+  if (typeof it.verified !== "boolean") return null;
+  if (typeof it.accounts !== "object" || it.accounts === null || Array.isArray(it.accounts)) {
+    return null;
+  }
+  return {
+    accessToken: it.accessToken,
+    refreshToken: it.refreshToken,
+    expirationDate: it.expirationDate,
+    verified: it.verified,
+    accounts: it.accounts as Record<string, unknown>,
+  };
+}
+
+/** Minimal surface of a WebContents this loop needs — keeps it testable
+ * without Electron. */
+export type AuthReader = () => Promise<unknown>;
+
+export interface AuthCapture {
+  start(onCaptured: (auth: CapturedAuth) => void): void;
+  stop(): void;
+}
+
+/**
+ * Polls the webview's localStorage until a valid session shows up. No
+ * timeout on purpose: MFA can take as long as the human needs; the loop only
+ * ends on success or stop() (login closed / webview detached). Polls overlap
+ * are guarded so a slow executeJavaScript can't double-fire.
+ */
+export function createAuthCapture(
+  executeJs: AuthReader,
+  opts: { intervalMs: number; setTimeout?: typeof setTimeout; clearTimeout?: typeof clearTimeout },
+): AuthCapture {
+  const setTimeout_ = opts.setTimeout ?? setTimeout;
+  const clearTimeout_ = opts.clearTimeout ?? clearTimeout;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = false;
+  let done = false;
+
+  async function poll(onCaptured: (auth: CapturedAuth) => void) {
+    if (done || inFlight) return;
+    inFlight = true;
+    try {
+      const raw = await executeJs();
+      const auth = parseCapturedAuth(typeof raw === "string" ? JSON.parse(raw) : raw);
+      if (auth) {
+        done = true;
+        onCaptured(auth);
+        return;
+      }
+    } catch {
+      // Webview mid-navigation or frame gone — the next tick retries.
+    } finally {
+      inFlight = false;
+    }
+    if (!done) timer = setTimeout_(() => void poll(onCaptured), opts.intervalMs);
+  }
+
+  return {
+    start(onCaptured) {
+      done = false;
+      void poll(onCaptured);
+    },
+    stop() {
+      done = true;
+      if (timer) {
+        clearTimeout_(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/src/main/auth/capture.ts
+++ b/src/main/auth/capture.ts
@@ -32,7 +32,8 @@ export function parseCapturedAuth(raw: unknown): CapturedAuth | null {
 export type AuthReader = () => Promise<unknown>;
 
 export interface AuthCapture {
-  start(onCaptured: (auth: CapturedAuth) => void): void;
+  /** Begins polling; returns false if the loop is already running. */
+  start(onCaptured: (auth: CapturedAuth) => void): boolean;
   stop(): void;
 }
 
@@ -72,9 +73,10 @@ export function createAuthCapture(
 
   return {
     start(onCaptured) {
-      if (running) return;
+      if (running) return false;
       running = true;
       void poll(onCaptured);
+      return true;
     },
     stop() {
       running = false;

--- a/src/main/auth/capture.ts
+++ b/src/main/auth/capture.ts
@@ -39,25 +39,26 @@ export interface AuthCapture {
 /**
  * Polls the webview's localStorage until a valid session shows up. No
  * timeout on purpose: MFA can take as long as the human needs; the loop only
- * ends on success or stop() (login closed / webview detached). Polls overlap
- * are guarded so a slow executeJavaScript can't double-fire.
+ * ends on success or stop() (login closed / webview left the origin). A hung
+ * reader must not wedge the loop, so only ever one poll is in flight and
+ * start() while already running is a no-op.
  */
 export function createAuthCapture(
   executeJs: AuthReader,
   opts: { intervalMs: number },
 ): AuthCapture {
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let running = false;
   let inFlight = false;
-  let done = false;
 
   async function poll(onCaptured: (auth: CapturedAuth) => void) {
-    if (done || inFlight) return;
+    if (!running || inFlight) return;
     inFlight = true;
     try {
       const raw = await executeJs();
       const auth = parseCapturedAuth(typeof raw === "string" ? JSON.parse(raw) : raw);
       if (auth) {
-        done = true;
+        running = false;
         onCaptured(auth);
         return;
       }
@@ -66,16 +67,17 @@ export function createAuthCapture(
     } finally {
       inFlight = false;
     }
-    if (!done) timer = setTimeout(() => void poll(onCaptured), opts.intervalMs);
+    if (running) timer = setTimeout(() => void poll(onCaptured), opts.intervalMs);
   }
 
   return {
     start(onCaptured) {
-      done = false;
+      if (running) return;
+      running = true;
       void poll(onCaptured);
     },
     stop() {
-      done = true;
+      running = false;
       if (timer) {
         clearTimeout(timer);
         timer = null;

--- a/src/main/auth/capture.ts
+++ b/src/main/auth/capture.ts
@@ -7,7 +7,9 @@ import type { CapturedAuth } from "../../shared/auth";
  */
 
 /** Accepts only the exact auth shape; anything else (login page leftovers,
- * garbage, half-writes) is not a session. */
+ * garbage, half-writes) is not a session. `accounts` arrives as an array
+ * (student + lecturer identities, per the webhook payload) — accept array or
+ * map, the app only needs the token in v1. */
 export function parseCapturedAuth(raw: unknown): CapturedAuth | null {
   if (typeof raw !== "object" || raw === null) return null;
   const it = raw as Record<string, unknown>;
@@ -15,15 +17,13 @@ export function parseCapturedAuth(raw: unknown): CapturedAuth | null {
   if (typeof it.refreshToken !== "string" || it.refreshToken.length === 0) return null;
   if (typeof it.expirationDate !== "string") return null;
   if (typeof it.verified !== "boolean") return null;
-  if (typeof it.accounts !== "object" || it.accounts === null || Array.isArray(it.accounts)) {
-    return null;
-  }
+  if (typeof it.accounts !== "object" || it.accounts === null) return null;
   return {
     accessToken: it.accessToken,
     refreshToken: it.refreshToken,
     expirationDate: it.expirationDate,
     verified: it.verified,
-    accounts: it.accounts as Record<string, unknown>,
+    accounts: it.accounts as CapturedAuth["accounts"],
   };
 }
 
@@ -51,6 +51,7 @@ export function createAuthCapture(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let running = false;
   let inFlight = false;
+  let warnedAboutValue = false;
 
   async function poll(onCaptured: (auth: CapturedAuth) => void) {
     if (!running || inFlight) return;
@@ -62,6 +63,16 @@ export function createAuthCapture(
         running = false;
         onCaptured(auth);
         return;
+      }
+      // A present-but-rejected value means the SPA's shape drifted from the
+      // validator — surface it once (keys only, never token values).
+      if (raw != null && !warnedAboutValue) {
+        warnedAboutValue = true;
+        const keys =
+          typeof raw === "string"
+            ? Object.keys(JSON.parse(raw) as Record<string, unknown>)
+            : Object.keys(raw as Record<string, unknown>);
+        console.log("[auth] poll saw a value that failed validation; keys:", keys);
       }
     } catch {
       // Webview mid-navigation or frame gone — the next tick retries.
@@ -75,6 +86,7 @@ export function createAuthCapture(
     start(onCaptured) {
       if (running) return false;
       running = true;
+      warnedAboutValue = false;
       void poll(onCaptured);
       return true;
     },

--- a/src/main/auth/session-manager.test.ts
+++ b/src/main/auth/session-manager.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSessionManager } from "./session-manager";
+import type { CapturedAuth } from "../../shared/auth";
+
+const session: CapturedAuth = {
+  accessToken: "eyJ.abc.def",
+  refreshToken: "def50200",
+  expirationDate: "2069-12-07T00:00:00.000Z",
+  verified: true,
+  accounts: { "0": { id: 190136 } },
+};
+
+function harness({
+  stored = null as CapturedAuth | null,
+  apiStatus = 200,
+}: { stored?: CapturedAuth | null; apiStatus?: number } = {}) {
+  const store = {
+    load: vi.fn(() => stored),
+    save: vi.fn(() => {}),
+    clear: vi.fn(() => {}),
+  };
+  const api = { get: vi.fn(async () => ({ status: apiStatus, ok: apiStatus < 400, body: null })) };
+  const onChange = vi.fn();
+  const manager = createSessionManager({ store, api, onChange });
+  return { manager, store, api, onChange };
+}
+
+describe("session manager", () => {
+  it("starts signed-out when nothing is stored", async () => {
+    const { manager, onChange } = harness();
+    await manager.restore();
+    expect(manager.status()).toBe("signed-out");
+    expect(onChange).toHaveBeenCalledWith("signed-out");
+  });
+
+  it("restores a stored session as signed-in without re-prompting (restart keeps the session)", async () => {
+    const { manager, api, onChange } = harness({ stored: session });
+    await manager.restore();
+    expect(manager.status()).toBe("signed-in");
+    expect(api.get).toHaveBeenCalledWith("/login/me");
+    expect(onChange).toHaveBeenCalledWith("signed-in");
+  });
+
+  it("a 401 on restore clears the stale session and asks for re-login", async () => {
+    const { manager, store, onChange } = harness({ stored: session, apiStatus: 401 });
+    await manager.restore();
+    expect(manager.status()).toBe("session-expired");
+    expect(store.clear).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("session-expired");
+  });
+
+  it("stays signed-in when restore cannot reach the API (offline ≠ signed out)", async () => {
+    const { manager } = harness({ stored: session, apiStatus: 0 });
+    await manager.restore();
+    expect(manager.status()).toBe("signed-in");
+  });
+
+  it("capture persists the tokens and flips to signed-in", async () => {
+    const { manager, store, onChange } = harness();
+    await manager.capture(session);
+    expect(store.save).toHaveBeenCalledWith(session);
+    expect(manager.status()).toBe("signed-in");
+    expect(onChange).toHaveBeenCalledWith("signed-in");
+  });
+
+  it("handleUnauthorized clears the session and pauses into session-expired", async () => {
+    const { manager, store } = harness({ stored: session });
+    await manager.restore();
+
+    manager.handleUnauthorized();
+    expect(manager.status()).toBe("session-expired");
+    expect(store.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("startLogin opens the webview moment and dismiss returns to where we were", async () => {
+    const { manager } = harness();
+    manager.startLogin();
+    expect(manager.status()).toBe("authenticating");
+    manager.dismissLogin();
+    expect(manager.status()).toBe("signed-out");
+  });
+
+  it("dismiss from a relogin lands back on session-expired, not stale data", async () => {
+    const { manager } = harness({ stored: session });
+    await manager.restore();
+    manager.handleUnauthorized();
+
+    manager.startLogin();
+    manager.dismissLogin();
+    expect(manager.status()).toBe("session-expired");
+  });
+
+  it("a successful capture from the relogin webview recovers without an app restart", async () => {
+    const { manager } = harness({ stored: session });
+    await manager.restore();
+    manager.handleUnauthorized();
+
+    manager.startLogin();
+    await manager.capture(session);
+    expect(manager.status()).toBe("signed-in");
+  });
+
+  it("capture verification 401 keeps the re-login moment up", async () => {
+    const { manager, onChange } = harness({ apiStatus: 401 });
+    await manager.capture(session);
+    // signed-in optimistically, then the /login/me probe bounces it back
+    expect(manager.status()).toBe("session-expired");
+    expect(onChange).toHaveBeenLastCalledWith("session-expired");
+  });
+});

--- a/src/main/auth/session-manager.test.ts
+++ b/src/main/auth/session-manager.test.ts
@@ -72,22 +72,10 @@ describe("session manager", () => {
     expect(store.clear).toHaveBeenCalledTimes(1);
   });
 
-  it("startLogin opens the webview moment and dismiss returns to where we were", async () => {
+  it("startLogin opens the webview moment", () => {
     const { manager } = harness();
     manager.startLogin();
     expect(manager.status()).toBe("authenticating");
-    manager.dismissLogin();
-    expect(manager.status()).toBe("signed-out");
-  });
-
-  it("dismiss from a relogin lands back on session-expired, not stale data", async () => {
-    const { manager } = harness({ stored: session });
-    await manager.restore();
-    manager.handleUnauthorized();
-
-    manager.startLogin();
-    manager.dismissLogin();
-    expect(manager.status()).toBe("session-expired");
   });
 
   it("a successful capture from the relogin webview recovers without an app restart", async () => {
@@ -100,11 +88,23 @@ describe("session manager", () => {
     expect(manager.status()).toBe("signed-in");
   });
 
-  it("capture verification 401 keeps the re-login moment up", async () => {
-    const { manager, onChange } = harness({ apiStatus: 401 });
+  it("capture with a verify 401 goes straight to session-expired, never through signed-in", async () => {
+    const { manager, onChange, store } = harness({ apiStatus: 401 });
+    manager.startLogin();
+
     await manager.capture(session);
-    // signed-in optimistically, then the /login/me probe bounces it back
+
     expect(manager.status()).toBe("session-expired");
-    expect(onChange).toHaveBeenLastCalledWith("session-expired");
+    expect(onChange).not.toHaveBeenCalledWith("signed-in");
+    expect(store.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("capture with the API unreachable still signs in — tokens were just minted", async () => {
+    const { manager } = harness({ apiStatus: 0 });
+    manager.startLogin();
+
+    await manager.capture(session);
+
+    expect(manager.status()).toBe("signed-in");
   });
 });

--- a/src/main/auth/session-manager.ts
+++ b/src/main/auth/session-manager.ts
@@ -91,6 +91,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
         console.error("[auth] could not persist session:", err);
       }
       const check = await deps.api.get("/login/me");
+      console.log("[auth] capture verify /login/me →", check.status);
       if (check.status === 401) {
         // The partition handed back stale tokens (a previous session's
         // localStorage.auth survived): straight into the re-login moment,

--- a/src/main/auth/session-manager.ts
+++ b/src/main/auth/session-manager.ts
@@ -28,9 +28,9 @@ export interface SessionManager {
   restore(): Promise<void>;
   /** Login webview is now open in the renderer. */
   startLogin(): void;
-  /** User closed the webview without finishing; return to the prior state. */
-  dismissLogin(): void;
-  /** `localStorage.auth` was captured out of the webview after the redirect. */
+  /** `localStorage.auth` was captured out of the webview after the redirect.
+   * Persists the tokens, then verifies before leaving authenticating — a
+   * stale partition must not flash signed-in and yank the webview away. */
   capture(auth: CapturedAuth): Promise<void>;
   /** 401 from any API use: pause everything into the re-login moment. */
   handleUnauthorized(): void;
@@ -41,7 +41,6 @@ export interface SessionManager {
 export function createSessionManager(deps: SessionManagerDeps): SessionManager {
   let status: AuthStatus = "signed-out";
   let token: string | null = null;
-  let preLoginStatus: AuthStatus = "signed-out";
 
   function transitionTo(next: AuthStatus) {
     if (status === next) return;
@@ -57,6 +56,8 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     async restore() {
       const stored = await deps.store.load();
       if (!stored) {
+        // Initial state is already signed-out; broadcast directly so the
+        // renderer leaves its boot gate even though nothing "changed".
         status = "signed-out";
         deps.onChange?.("signed-out");
         return;
@@ -67,7 +68,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
         // Stale session (cookies don't survive restarts anyway): clear it and
         // surface the re-login moment instead of showing stale data.
         token = null;
-        await deps.store.clear();
+        deps.store.clear();
         transitionTo("session-expired");
         return;
       }
@@ -77,17 +78,11 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     },
 
     startLogin() {
-      if (status !== "authenticating") preLoginStatus = status;
       transitionTo("authenticating");
-    },
-
-    dismissLogin() {
-      transitionTo(preLoginStatus);
     },
 
     async capture(auth) {
       token = auth.accessToken;
-      transitionTo("signed-in");
       try {
         await deps.store.save(auth);
       } catch (err) {
@@ -97,14 +92,20 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       }
       const check = await deps.api.get("/login/me");
       if (check.status === 401) {
+        // The partition handed back stale tokens (a previous session's
+        // localStorage.auth survived): straight into the re-login moment,
+        // never through a signed-in flash.
         this.handleUnauthorized();
+        return;
       }
+      // 200 → healthy; unreachable → the tokens were just minted by the SSO
+      // redirect, accept them and let the next online check re-verify.
+      transitionTo("signed-in");
     },
 
     handleUnauthorized() {
       token = null;
       void deps.store.clear();
-      preLoginStatus = "session-expired";
       transitionTo("session-expired");
     },
   };

--- a/src/main/auth/session-manager.ts
+++ b/src/main/auth/session-manager.ts
@@ -1,0 +1,111 @@
+import type { AuthStatus, CapturedAuth } from "../../shared/auth";
+
+/**
+ * The auth state machine (see AuthStatus in shared/auth.ts). Owns the tokens
+ * in main; the renderer only ever sees the status. Recovery is interactive
+ * by design — there is deliberately no refresh logic anywhere (spec: auth &
+ * session): a 401 or a missing token clears the session and pauses the app
+ * into the "please sign in again" moment, which reopens the login webview.
+ */
+
+export interface SessionStoreLike {
+  load(): CapturedAuth | null;
+  save(session: CapturedAuth): void;
+  clear(): void;
+}
+
+export interface SessionManagerDeps {
+  store: SessionStoreLike;
+  /** Client used for the one verification GET the auth slice makes. */
+  api: { get(path: string): Promise<{ status: number }> };
+  onChange?(status: AuthStatus): void;
+}
+
+export interface SessionManager {
+  status(): AuthStatus;
+  /** Startup: restore from the encrypted store, verifying the token still
+   * works. Signed-in stays signed-in when the check can't reach the network. */
+  restore(): Promise<void>;
+  /** Login webview is now open in the renderer. */
+  startLogin(): void;
+  /** User closed the webview without finishing; return to the prior state. */
+  dismissLogin(): void;
+  /** `localStorage.auth` was captured out of the webview after the redirect. */
+  capture(auth: CapturedAuth): Promise<void>;
+  /** 401 from any API use: pause everything into the re-login moment. */
+  handleUnauthorized(): void;
+  /** Token handed to the API client. */
+  accessToken(): string | null;
+}
+
+export function createSessionManager(deps: SessionManagerDeps): SessionManager {
+  let status: AuthStatus = "signed-out";
+  let token: string | null = null;
+  let preLoginStatus: AuthStatus = "signed-out";
+
+  function transitionTo(next: AuthStatus) {
+    if (status === next) return;
+    status = next;
+    deps.onChange?.(next);
+  }
+
+  return {
+    status: () => status,
+
+    accessToken: () => token,
+
+    async restore() {
+      const stored = await deps.store.load();
+      if (!stored) {
+        status = "signed-out";
+        deps.onChange?.("signed-out");
+        return;
+      }
+      token = stored.accessToken;
+      const check = await deps.api.get("/login/me");
+      if (check.status === 401) {
+        // Stale session (cookies don't survive restarts anyway): clear it and
+        // surface the re-login moment instead of showing stale data.
+        token = null;
+        await deps.store.clear();
+        transitionTo("session-expired");
+        return;
+      }
+      // 200 → healthy; unreachable/offline → keep the session, the next sync
+      // tick will re-check. Only a real 401 signs the user out.
+      transitionTo("signed-in");
+    },
+
+    startLogin() {
+      if (status !== "authenticating") preLoginStatus = status;
+      transitionTo("authenticating");
+    },
+
+    dismissLogin() {
+      transitionTo(preLoginStatus);
+    },
+
+    async capture(auth) {
+      token = auth.accessToken;
+      transitionTo("signed-in");
+      try {
+        await deps.store.save(auth);
+      } catch (err) {
+        // safeStorage refused (e.g. no keyring): the session works this run
+        // but can never survive a restart — never write plaintext instead.
+        console.error("[auth] could not persist session:", err);
+      }
+      const check = await deps.api.get("/login/me");
+      if (check.status === 401) {
+        this.handleUnauthorized();
+      }
+    },
+
+    handleUnauthorized() {
+      token = null;
+      void deps.store.clear();
+      preLoginStatus = "session-expired";
+      transitionTo("session-expired");
+    },
+  };
+}

--- a/src/main/auth/session-store.test.ts
+++ b/src/main/auth/session-store.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createSessionStore } from "./session-store";
+import type { CapturedAuth } from "../../shared/auth";
+
+const session: CapturedAuth = {
+  accessToken: "eyJ0eXAiOiJK.abc.def",
+  refreshToken: "def50200b172",
+  expirationDate: "2069-12-07T00:00:00.000Z",
+  verified: true,
+  accounts: { "0": { id: 190136 } },
+};
+
+/** Round-trip codec standing in for safeStorage — same contract, no Keychain.
+ * Base64 so the no-plaintext assertion below is real, not vacuous. */
+const codec = {
+  encrypt: (plain: string) => Buffer.from(plain, "utf8").toString("base64"),
+  decrypt: (blob: Buffer) => Buffer.from(blob.toString("utf8"), "base64").toString("utf8"),
+};
+
+function tmpFile() {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), "edunex-auth-")), "session.bin");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("session store", () => {
+  it("round-trips a session through the encrypting codec", () => {
+    const file = tmpFile();
+    const store = createSessionStore(file, codec);
+
+    store.save(session);
+
+    // Never plaintext on disk: the file must not contain the raw token.
+    expect(fs.readFileSync(file, "utf8")).not.toContain("eyJ0eXAiOiJK");
+    expect(store.load()).toEqual(session);
+  });
+
+  it("loads null when nothing is stored", () => {
+    expect(createSessionStore(tmpFile(), codec).load()).toBeNull();
+  });
+
+  it("loads null from an undecryptable file instead of crashing startup", () => {
+    const file = tmpFile();
+    fs.writeFileSync(file, Buffer.from("garbage"));
+    expect(createSessionStore(file, codec).load()).toBeNull();
+  });
+
+  it("loads null from a file holding non-auth JSON", () => {
+    const file = tmpFile();
+    const store = createSessionStore(file, codec);
+    fs.writeFileSync(file, codec.encrypt(JSON.stringify({ nope: true })));
+    expect(store.load()).toBeNull();
+  });
+
+  it("clear removes the stored session", () => {
+    const file = tmpFile();
+    const store = createSessionStore(file, codec);
+    store.save(session);
+
+    store.clear();
+
+    expect(store.load()).toBeNull();
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it("clear tolerates a missing file", () => {
+    const store = createSessionStore(tmpFile(), codec);
+    expect(() => store.clear()).not.toThrow();
+  });
+});

--- a/src/main/auth/session-store.ts
+++ b/src/main/auth/session-store.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import type { CapturedAuth } from "../../shared/auth";
+import { parseCapturedAuth } from "./capture";
+
+/**
+ * Tokens at rest via safeStorage (spec: auth & session) — the codec abstracts
+ * encrypt/decrypt so tests run without a Keychain and main injects the real
+ * safeStorage-backed one. If the codec fails, no plaintext fallback is ever
+ * written: the store stays empty and the user signs in again.
+ */
+export interface SessionCodec {
+  encrypt(plaintext: string): Buffer;
+  decrypt(blob: Buffer): string;
+}
+
+export interface SessionStore {
+  load(): CapturedAuth | null;
+  save(session: CapturedAuth): void;
+  clear(): void;
+}
+
+export function createSessionStore(
+  filePath: string,
+  codec: SessionCodec,
+  fsLike: Pick<typeof fs, "readFileSync" | "writeFileSync" | "rmSync" | "existsSync"> = fs,
+): SessionStore {
+  function load(): CapturedAuth | null {
+    let blob: Buffer;
+    try {
+      blob = fsLike.readFileSync(filePath);
+    } catch {
+      return null;
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(codec.decrypt(blob));
+    } catch {
+      return null;
+    }
+    return parseCapturedAuth(raw);
+  }
+
+  function save(session: CapturedAuth): void {
+    fsLike.writeFileSync(filePath, codec.encrypt(JSON.stringify(session)));
+  }
+
+  function clear(): void {
+    try {
+      fsLike.rmSync(filePath);
+    } catch {
+      // No file to clear — already the desired state.
+    }
+  }
+
+  return { load, save, clear };
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -177,7 +177,12 @@ function sendToView(view: string) {
 function setApplicationMenu() {
   Menu.setApplicationMenu(
     Menu.buildFromTemplate(
-      buildAppMenuTemplate(app.name, NAV_VIEWS, { gotoView: sendToView }),
+      buildAppMenuTemplate(app.name, NAV_VIEWS, {
+        gotoView: sendToView,
+        // Dev-only hook to demo the re-login moment (#18) without needing the
+        // vendor API to actually reject a session.
+        simulateUnauthorized: app.isPackaged ? undefined : () => authController.simulateUnauthorized(),
+      }),
     ),
   );
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,6 +13,7 @@ import { buildTrayMenuTemplate } from "./tray-menu";
 import { buildAppMenuTemplate } from "./app-menu";
 import { loadWindowState, saveWindowState, type WindowState } from "./window-state";
 import { shouldFireStartupTestNotification } from "./notifications";
+import { createAuthController } from "./auth/auth-controller";
 import { NAV_VIEWS } from "../shared/shell";
 
 // Windows routes notifications by AppUserModelID; without it they fall under
@@ -61,6 +62,9 @@ function createWindow(state?: WindowState | null) {
       preload: path.join(__dirname, "../preload/preload.js"),
       contextIsolation: true,
       nodeIntegration: false,
+      // The embedded login webview (#18) lives in the renderer on a
+      // persistent partition; capture and state stay in main.
+      webviewTag: true,
     },
   });
 
@@ -74,6 +78,13 @@ function createWindow(state?: WindowState | null) {
   // re-aligns the brand row when they're gone.
   win.on("enter-full-screen", () => win?.webContents.send("window:fullscreen", true));
   win.on("leave-full-screen", () => win?.webContents.send("window:fullscreen", false));
+
+  // The login webview (#18) attaches here whenever the renderer mounts it.
+  // Main owns the capture loop and popup suppression for its webContents;
+  // the loop ends with the webview's own destroyed event.
+  win.webContents.on("did-attach-webview", (_event, contents) =>
+    authController.attachWebview(contents),
+  );
 
   win.on("resize", queueWindowStateSave);
   win.on("move", queueWindowStateSave);
@@ -171,6 +182,16 @@ function setApplicationMenu() {
   );
 }
 
+// Auth slice (#18): encrypted token store, capture from the login webview,
+// and the signed-out / authenticating / signed-in / session-expired machine.
+const authController = createAuthController({
+  sessionStorePath: path.join(app.getPath("userData"), "auth-session.enc"),
+  appVersion: app.getVersion(),
+  broadcast: (status) => {
+    if (win && !win.isDestroyed()) win.webContents.send("auth:state", status);
+  },
+});
+
 if (!gotSingleInstanceLock) {
   app.quit();
 } else {
@@ -186,6 +207,11 @@ if (!gotSingleInstanceLock) {
     }
     createWindow(loadWindowState(windowStatePath(), screen.getPrimaryDisplay().workArea));
     createTray();
+
+    // Restore the session before the renderer finishes booting; until this
+    // resolves the renderer holds back the auth-gated UI (status stays null)
+    // so a restored session never flashes the login view.
+    void authController.restore();
 
     app.setAboutPanelOptions({
       applicationName: "Edunex Plus",
@@ -205,6 +231,13 @@ if (!gotSingleInstanceLock) {
     trayActive: tray != null,
     notificationsSupported: Notification.isSupported(),
   }));
+
+  // Auth slice (#18): the renderer asks for the current status, requests the
+  // login webview moment, or dismisses it; state changes arrive pushed on
+  // auth:state.
+  ipcMain.handle("auth:get-state", () => authController.status());
+  ipcMain.handle("auth:start-login", () => authController.startLogin());
+  ipcMain.handle("auth:dismiss-login", () => authController.dismissLogin());
 
   // Deliberate no-op while a tray exists: closing the window must not end the
   // process — the app lives in the tray so notifications keep flowing (spec:

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -232,12 +232,10 @@ if (!gotSingleInstanceLock) {
     notificationsSupported: Notification.isSupported(),
   }));
 
-  // Auth slice (#18): the renderer asks for the current status, requests the
-  // login webview moment, or dismisses it; state changes arrive pushed on
-  // auth:state.
+  // Auth slice (#18): the renderer asks for the current status or requests
+  // the login webview moment; state changes arrive pushed on auth:state.
   ipcMain.handle("auth:get-state", () => authController.status());
   ipcMain.handle("auth:start-login", () => authController.startLogin());
-  ipcMain.handle("auth:dismiss-login", () => authController.dismissLogin());
 
   // Deliberate no-op while a tray exists: closing the window must not end the
   // process — the app lives in the tray so notifications keep flowing (spec:

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -26,7 +26,6 @@ contextBridge.exposeInMainWorld("edunex", {
   // Auth (#18): null until main's startup restore has resolved.
   getAuthState: () => ipcRenderer.invoke("auth:get-state") as Promise<AuthStatus | null>,
   startLogin: () => ipcRenderer.invoke("auth:start-login") as Promise<void>,
-  dismissLogin: () => ipcRenderer.invoke("auth:dismiss-login") as Promise<void>,
   onAuthState: (callback: (status: AuthStatus) => void) => {
     const listener = (_event: unknown, status: AuthStatus) => callback(status);
     ipcRenderer.on("auth:state", listener);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
+import type { AuthStatus } from "../shared/auth";
 import type { AppInfo, NavKey } from "../shared/shell";
 
 contextBridge.exposeInMainWorld("edunex", {
@@ -21,5 +22,14 @@ contextBridge.exposeInMainWorld("edunex", {
     const listener = (_event: unknown, isFullscreen: boolean) => callback(isFullscreen);
     ipcRenderer.on("window:fullscreen", listener);
     return () => ipcRenderer.removeListener("window:fullscreen", listener);
+  },
+  // Auth (#18): null until main's startup restore has resolved.
+  getAuthState: () => ipcRenderer.invoke("auth:get-state") as Promise<AuthStatus | null>,
+  startLogin: () => ipcRenderer.invoke("auth:start-login") as Promise<void>,
+  dismissLogin: () => ipcRenderer.invoke("auth:dismiss-login") as Promise<void>,
+  onAuthState: (callback: (status: AuthStatus) => void) => {
+    const listener = (_event: unknown, status: AuthStatus) => callback(status);
+    ipcRenderer.on("auth:state", listener);
+    return () => ipcRenderer.removeListener("auth:state", listener);
   },
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import { AppSidebar } from "./components/app-sidebar";
 import { SystemPanel } from "./features/shell/system-panel";
+import { LoginView } from "./features/auth/login-view";
+import { ReloginModal } from "./features/auth/relogin-modal";
+import { useAuthState } from "./features/auth/use-auth-state";
 import { navItem } from "./nav";
 import { cx } from "./utils/cx";
 import type { NavKey } from "@shared/shell";
@@ -11,15 +14,30 @@ import type { NavKey } from "@shared/shell";
  * from type weight, contrast and one hairline between rail and content.
  * macOS runs the hidden titlebar (traffic lights live in the sidebar
  * header); Windows/Linux keep the standard frame with the same layout minus
- * drag regions. Views are placeholders naming the slice each surface lands
- * in — no EduNex data or auth in the shell.
+ * drag regions.
+ *
+ * Auth gating (#18): the shell holds back on a null status (startup restore
+ * in flight), shows the embedded SSO webview while signed out or mid-login,
+ * and lays the "please sign in again" modal over the paused shell when the
+ * session has expired.
  */
 export function App() {
   const [activeKey, setActiveKey] = useState<NavKey>("home");
+  const authStatus = useAuthState();
   const active = navItem(activeKey);
   const isMac = window.edunex.platform === "darwin";
 
   useEffect(() => window.edunex.onNavigate(setActiveKey), []);
+
+  if (authStatus === null) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background-primary-default">
+        <p className="text-[13px] text-text-tertiary">Starting…</p>
+      </div>
+    );
+  }
+
+  const showLogin = authStatus === "signed-out" || authStatus === "authenticating";
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -31,7 +49,9 @@ export function App() {
             isMac && "app-drag",
           )}
         >
-          <h1 className="text-[15px] font-semibold tracking-tight">{active.label}</h1>
+          <h1 className="text-[15px] font-semibold tracking-tight">
+            {showLogin ? "Sign in" : active.label}
+          </h1>
           <span
             className={cx(
               "ml-auto text-caption-1-regular text-text-tertiary",
@@ -41,13 +61,25 @@ export function App() {
             v{window.edunex.version}
           </span>
         </header>
-        <div className="app-scrollbar flex-1 overflow-y-auto px-8 pb-10 pt-2">
-          <p className="max-w-prose text-[13px] leading-5 text-text-secondary">
-            {active.placeholder}
-          </p>
-          {activeKey === "home" && <SystemPanel />}
+        <div
+          className={cx(
+            "min-h-0 flex-1 px-8 pb-10 pt-2",
+            showLogin ? "overflow-hidden" : "app-scrollbar overflow-y-auto",
+          )}
+        >
+          {showLogin ? (
+            <LoginView />
+          ) : (
+            <>
+              <p className="max-w-prose text-[13px] leading-5 text-text-secondary">
+                {active.placeholder}
+              </p>
+              {activeKey === "home" && <SystemPanel />}
+            </>
+          )}
         </div>
       </main>
+      {authStatus === "session-expired" && <ReloginModal />}
     </div>
   );
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,7 +41,7 @@ export function App() {
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <AppSidebar activeKey={activeKey} onSelect={setActiveKey} />
+      <AppSidebar activeKey={activeKey} onSelect={setActiveKey} signedIn={authStatus === "signed-in"} />
       <main className="flex min-w-0 flex-1 flex-col border-l border-black/[0.08] bg-background-primary-default">
         <header
           className={cx(

--- a/src/renderer/components/app-sidebar.tsx
+++ b/src/renderer/components/app-sidebar.tsx
@@ -16,9 +16,10 @@ import { NAV_ITEMS, type NavKey } from "@/nav";
 export interface AppSidebarProps {
   activeKey: NavKey;
   onSelect: (key: NavKey) => void;
+  signedIn: boolean;
 }
 
-export function AppSidebar({ activeKey, onSelect }: AppSidebarProps) {
+export function AppSidebar({ activeKey, onSelect, signedIn }: AppSidebarProps) {
   const isMac = window.edunex.platform === "darwin";
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -82,9 +83,11 @@ export function AppSidebar({ activeKey, onSelect }: AppSidebarProps) {
             <i className="ri-user-3-line text-[15px]" aria-hidden />
           </span>
           <div className="min-w-0">
-            <div className="text-[13px] font-medium leading-4">Not signed in</div>
+            <div className="text-[13px] font-medium leading-4">
+              {signedIn ? "Signed in" : "Not signed in"}
+            </div>
             <div className="text-caption-1-regular text-text-tertiary">
-              INA sign-in lands in #18
+              {signedIn ? "INA account" : "Sign in with your INA account"}
             </div>
           </div>
         </div>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -19,7 +19,6 @@ declare global {
       onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void;
       getAuthState(): Promise<AuthStatus | null>;
       startLogin(): Promise<void>;
-      dismissLogin(): Promise<void>;
       onAuthState(callback: (status: AuthStatus) => void): () => void;
     };
   }

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -1,3 +1,4 @@
+import type { AuthStatus } from "@shared/auth";
 import type { AppInfo, NavKey } from "@shared/shell";
 
 export {};
@@ -16,6 +17,27 @@ declare global {
       getAppInfo(): Promise<AppInfo>;
       onNavigate(callback: (view: NavKey) => void): () => void;
       onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void;
+      getAuthState(): Promise<AuthStatus | null>;
+      startLogin(): Promise<void>;
+      dismissLogin(): Promise<void>;
+      onAuthState(callback: (status: AuthStatus) => void): () => void;
     };
+  }
+}
+
+/**
+ * The embedded login webview (#18): a plain <webview> tag on the persistent
+ * auth partition. Capture of localStorage.auth happens in main via the
+ * did-attach-webview hook — the renderer never touches token contents.
+ */
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      webview: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        src?: string;
+        partition?: string;
+        allowpopups?: string;
+      };
+    }
   }
 }

--- a/src/renderer/features/auth/login-view.tsx
+++ b/src/renderer/features/auth/login-view.tsx
@@ -1,22 +1,58 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import { LoginWebview } from "./login-webview";
 
 /**
- * First-run sign-in surface (#18): a short, calm explainer and the embedded
- * SSO webview filling the content panel.
+ * The sign-in surface (#18). Two phases, both ours — the cluttered EduNex
+ * login page never appears:
+ * 1. A calm branded intro; nothing loads until the user asks for it.
+ * 2. The embedded webview starting at the ITB SSO broker, which hands off to
+ *    Microsoft's own Azure AD page (MFA included). The password only ever
+ *    reaches Microsoft; main captures the session after the redirect-back.
  */
 export function LoginView() {
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="shrink-0 px-1 pb-4">
-        <h2 className="text-[15px] font-semibold tracking-tight">Sign in with your INA account</h2>
-        <p className="mt-1 max-w-prose text-[13px] leading-5 text-text-secondary">
-          The ITB SSO (including MFA) opens right here. Your password goes only to
-          Microsoft/Azure — Edunex Plus captures the resulting session and never sees
-          your credentials.
-        </p>
+  const [ssoStarted, setSsoStarted] = useState(false);
+
+  if (ssoStarted) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="shrink-0 px-1 pb-3">
+          <h2 className="text-[15px] font-semibold tracking-tight">ITB Single Sign-On</h2>
+          <p className="mt-1 max-w-prose text-[13px] leading-5 text-text-secondary">
+            Sign in on Microsoft's page below — MFA included. Edunex Plus never sees
+            your password; the session is captured automatically once the redirect
+            finishes.
+          </p>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-black/[0.06]">
+          <LoginWebview />
+        </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-black/[0.06]">
-        <LoginWebview />
+    );
+  }
+
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="w-[400px] text-center">
+        <span className="mx-auto grid size-12 place-items-center rounded-xl bg-linear-to-b from-accent-500 to-accent-600 text-[19px] font-bold text-white">
+          e+
+        </span>
+        <h2 className="mt-5 text-[19px] font-semibold tracking-tight">
+          Sign in with your INA account
+        </h2>
+        <p className="mx-auto mt-2 max-w-[340px] text-[13px] leading-5 text-text-secondary">
+          One sign-in through ITB's SSO and Edunex Plus takes care of the rest. Your
+          password goes only to Microsoft's own sign-in page — the app captures the
+          resulting session and never sees your credentials.
+        </p>
+        <div className="mt-6 flex justify-center">
+          <Button variant="primary" onClick={() => setSsoStarted(true)}>
+            Continue to ITB SSO
+          </Button>
+        </div>
+        <p className="mt-4 text-caption-1-regular text-text-tertiary">
+          ITB Single Sign-On · Azure AD · MFA supported
+        </p>
       </div>
     </div>
   );

--- a/src/renderer/features/auth/login-view.tsx
+++ b/src/renderer/features/auth/login-view.tsx
@@ -1,0 +1,23 @@
+import { LoginWebview } from "./login-webview";
+
+/**
+ * First-run sign-in surface (#18): a short, calm explainer and the embedded
+ * SSO webview filling the content panel.
+ */
+export function LoginView() {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 px-1 pb-4">
+        <h2 className="text-[15px] font-semibold tracking-tight">Sign in with your INA account</h2>
+        <p className="mt-1 max-w-prose text-[13px] leading-5 text-text-secondary">
+          The ITB SSO (including MFA) opens right here. Your password goes only to
+          Microsoft/Azure — Edunex Plus captures the resulting session and never sees
+          your credentials.
+        </p>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-black/[0.06]">
+        <LoginWebview />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/auth/login-webview.tsx
+++ b/src/renderer/features/auth/login-webview.tsx
@@ -1,16 +1,17 @@
-import { AUTH_PARTITION, EDUNEX_LOGIN_URL } from "@shared/auth";
+import { EDUNEX_SSO_URL } from "@shared/auth";
+import { AUTH_PARTITION } from "@shared/auth";
 
 /**
- * The embedded login webview (#18). The full INA SSO — Azure AD via ITB's
- * broker, MFA included — completes inside this view with zero popups (main
- * folds any window.open back into it). The password only ever reaches
+ * The embedded SSO webview (#18), starting at the ITB broker. The full INA
+ * SSO — Azure AD, MFA included — completes inside this view with zero popups
+ * (main folds any window.open back into it). The password only ever reaches
  * Microsoft/Azure pages; main captures localStorage.auth out of this
  * partition after the redirect-back and the app never sees the credentials.
  */
 export function LoginWebview() {
   return (
     <webview
-      src={EDUNEX_LOGIN_URL}
+      src={EDUNEX_SSO_URL}
       partition={AUTH_PARTITION}
       className="h-full w-full bg-white"
     />

--- a/src/renderer/features/auth/login-webview.tsx
+++ b/src/renderer/features/auth/login-webview.tsx
@@ -1,0 +1,18 @@
+import { AUTH_PARTITION, EDUNEX_LOGIN_URL } from "@shared/auth";
+
+/**
+ * The embedded login webview (#18). The full INA SSO — Azure AD via ITB's
+ * broker, MFA included — completes inside this view with zero popups (main
+ * folds any window.open back into it). The password only ever reaches
+ * Microsoft/Azure pages; main captures localStorage.auth out of this
+ * partition after the redirect-back and the app never sees the credentials.
+ */
+export function LoginWebview() {
+  return (
+    <webview
+      src={EDUNEX_LOGIN_URL}
+      partition={AUTH_PARTITION}
+      className="h-full w-full bg-white"
+    />
+  );
+}

--- a/src/renderer/features/auth/relogin-modal.tsx
+++ b/src/renderer/features/auth/relogin-modal.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@/components/ui/button";
+
+/**
+ * The modal "please sign in again" moment (#18, user story 4): a 401 or a
+ * missing token paused the app — this modal makes that pause visible and
+ * reopens the login webview. Completing the SSO recovers the session without
+ * an app restart; there is deliberately no silent re-login or refresh logic
+ * (spec: auth & session). "Sign in again" flips the auth machine to
+ * authenticating, which swaps this modal for the embedded webview.
+ */
+export function ReloginModal() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-[2px]">
+      <div className="w-[min(560px,90vw)] rounded-2xl bg-background-primary-default p-6 shadow-2xl">
+        <h2 className="text-[15px] font-semibold tracking-tight">Please sign in again</h2>
+        <p className="mt-2 text-[13px] leading-5 text-text-secondary">
+          Your session is no longer valid, so the app paused instead of showing stale
+          data. Nothing was lost — signing in again with your INA account picks up
+          where you left off.
+        </p>
+        <div className="mt-5">
+          <Button variant="primary" onClick={() => void window.edunex.startLogin()}>
+            Sign in again
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/auth/use-auth-state.ts
+++ b/src/renderer/features/auth/use-auth-state.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import type { AuthStatus } from "@shared/auth";
+
+/**
+ * Mirrors main's auth state machine. Null until main's startup restore has
+ * resolved — callers hold the shell back on null so a restored session never
+ * flashes the login view (issue #18).
+ */
+export function useAuthState(): AuthStatus | null {
+  const [status, setStatus] = useState<AuthStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.edunex.getAuthState().then((initial) => {
+      if (!cancelled && initial !== null) setStatus(initial);
+    });
+    const unsubscribe = window.edunex.onAuthState(setStatus);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/renderer/features/auth/use-auth-state.ts
+++ b/src/renderer/features/auth/use-auth-state.ts
@@ -11,8 +11,10 @@ export function useAuthState(): AuthStatus | null {
 
   useEffect(() => {
     let cancelled = false;
+    // prev ?? initial: a pushed status that arrived before this promise
+    // resolved must not be overwritten by the (older) initial value.
     void window.edunex.getAuthState().then((initial) => {
-      if (!cancelled && initial !== null) setStatus(initial);
+      if (!cancelled) setStatus((prev) => prev ?? initial);
     });
     const unsubscribe = window.edunex.onAuthState(setStatus);
     return () => {

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -12,8 +12,9 @@ export interface CapturedAuth {
   /** 2069 sentinel in practice; the SPA never refreshes (spec: auth & session). */
   expirationDate: string;
   verified: boolean;
-  /** Account map keyed "0","1",… — v1 is single-account, used as-is. */
-  accounts: Record<string, unknown>;
+  /** The student's identities (array from the SSO webhook — student +
+   * lecturer rows) or the SPA's keyed map; v1 is single-account, unused. */
+  accounts: unknown[] | Record<string, unknown>;
 }
 
 /**

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -27,9 +27,11 @@ export interface CapturedAuth {
  */
 export type AuthStatus = "signed-out" | "authenticating" | "signed-in" | "session-expired";
 
-/** Where the SSO journey starts; lands back on edunex.itb.ac.id after the
- * redirect (auth-spike). Used by the renderer's webview src. */
-export const EDUNEX_LOGIN_URL = "https://edunex.itb.ac.id/pages/login?to=%2F";
+/** Start of the SSO journey: the ITB broker straight to Azure AD — skipping
+ * the cluttered EduNex login page entirely. The redirect-back lands on
+ * edunex.itb.ac.id, where the capture polls (auth-spike). Used by the
+ * renderer's webview src. */
+export const EDUNEX_SSO_URL = "https://sso-edunex.itb.ac.id/";
 
 /** Persistent partition for the login webview — survives restarts so the SSO
  * broker can remember the device. Never share across app instances (the

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,0 +1,37 @@
+/**
+ * Auth contracts shared between main and renderer (#18). Dependency-free so
+ * every side can use it (see src/shared/shell.ts).
+ */
+
+/** The shape of `localStorage.auth` on edunex.itb.ac.id after the SSO
+ * redirect-back (verified by prototype/auth-spike). The app never sees the
+ * password — only this post-login artifact. */
+export interface CapturedAuth {
+  accessToken: string;
+  refreshToken: string;
+  /** 2069 sentinel in practice; the SPA never refreshes (spec: auth & session). */
+  expirationDate: string;
+  verified: boolean;
+  /** Account map keyed "0","1",… — v1 is single-account, used as-is. */
+  accounts: Record<string, unknown>;
+}
+
+/**
+ * The auth state machine, owned by main and mirrored in the renderer:
+ * - signed-out: no stored session — embedded login webview fills the panel.
+ * - authenticating: the login webview is open (first sign-in or relogin).
+ * - signed-in: tokens captured/restored and accepted.
+ * - session-expired: a 401 or missing token paused the app; the "please sign
+ *   in again" modal is up. Recovery is interactive by design — no refresh
+ *   logic anywhere (spec: auth & session).
+ */
+export type AuthStatus = "signed-out" | "authenticating" | "signed-in" | "session-expired";
+
+/** Where the SSO journey starts; lands back on edunex.itb.ac.id after the
+ * redirect (auth-spike). Used by the renderer's webview src. */
+export const EDUNEX_LOGIN_URL = "https://edunex.itb.ac.id/pages/login?to=%2F";
+
+/** Persistent partition for the login webview — survives restarts so the SSO
+ * broker can remember the device. Never share across app instances (the
+ * single-instance lock guards this; spec: auth & session). */
+export const AUTH_PARTITION = "persist:edunex-auth";


### PR DESCRIPTION
## Parent

- Closes #18 (Spec: Auth & session, from #17)
- Stacks on `feat/app-shell` (#32) — retarget to `main` once that merges.

## What landed

The full login slice, with every decision from the spec's auth section:

- **Embedded login webview** on the `persist:edunex-auth` partition behind a calm branded intro card. The EduNex login page never appears — the webview starts at the ITB SSO broker and hands off to Microsoft's own Azure AD page. Zero popups: `setWindowOpenHandler` folds any `window.open` back into the same view.
- **Token capture** — main polls the webview's `localStorage.auth` every 1s while it sits on the edunex origin (starts/stops on `did-navigate`; every read is wrapped in a 5s timeout so a wedged frame can't stall the loop; MFA may take as long as the human needs — no timeout on the journey itself).
- **Encrypted persistence** — tokens go through safeStorage into `auth-session.enc` (Keychain-backed ciphertext, never plaintext on disk). If safeStorage is unavailable the store refuses to write rather than fall back.
- **Direct API client** — bearer token + distinctive `EdunexPlus/<version>` User-Agent; 401 or missing token fires the unauthorized signal, network failures don't (offline ≠ signed out).
- **State machine** — `signed-out → authenticating → signed-in`, with `session-expired` pausing the app into the modal re-login moment. Capture verifies via `/login/me` *before* leaving `authenticating`, so a stale partition can't flash signed-in. There is deliberately no refresh logic anywhere.
- **Dev-only View → Simulate 401** menu item to demo the modal → sign-in-again → recovery loop without needing the vendor API to reject a token. Packaged builds never see it.

## Live-proven (user's real INA session)

- Full SSO completed in-window, zero popups; capture verified `/login/me → 200`
- `auth-session.enc` written as safeStorage ciphertext (no plaintext tokens)
- Restart restored the session: `startup restore complete: signed-in`, no re-login

## Testing

44 vitest tests across the three seams (network, state machine, capture timing) plus the menu template. Both tsconfigs clean. `parseCapturedAuth` accepts the SPA's real shape — `accounts` is an **array** of identities (student + lecturer rows) from the webhook; accepting only a map rejected every real capture, which is the bug the first live run caught.

## Notes for review

- Edunex-origin URLs can carry the bearer token as a query param (`/webhook/sso`) — auth logs deliberately record pathname only, never query strings.
- The `session-expired` modal is intentionally inescapable (no "Later"): the app is paused, and recovery is interactive by verified design.
- "Sync pauses" on 401 is fully realized by the sync slice; this slice provides the mechanism (`handleUnauthorized` → modal) it will call.